### PR TITLE
Bump min composer.json version to 8.3

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -13,12 +13,8 @@ jobs:
       max-parallel: 3
       matrix:
         php:
-          - 7.3
-          - 7.4
-          - 8.0
-          - 8.1
-          - 8.2
           - 8.3
+          - 8.4
         composer:
           - 2
     name: Test - php:${{ matrix.php }}; composer:${{ matrix.composer }}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "myclabs/php-enum": "^1.8",
-    "php": "^7.3 || ^8.0"
+    "php": ">8.3"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "myclabs/php-enum": "^1.8",
-    "php": ">8.3"
+    "php": ">=8.3"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,16 @@
     }
   ],
   "require": {
-    "myclabs/php-enum": "^1.8",
     "php": ">=8.3"
   },
   "autoload": {
     "psr-4": {
       "Imponeer\\Database\\Criteria\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Imponeer\\Database\\Criteria\\Tests\\": "tests/"
     }
   },
   "keywords": [

--- a/src/CriteriaCompo.php
+++ b/src/CriteriaCompo.php
@@ -5,6 +5,7 @@ namespace Imponeer\Database\Criteria;
 use Exception;
 use Imponeer\Database\Criteria\Enum\Condition;
 use IteratorAggregate;
+use Stringable;
 use Traversable;
 
 /**
@@ -107,5 +108,13 @@ class CriteriaCompo extends CriteriaElement implements IteratorAggregate
         }
 
         return $ret;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function __toString(): string
+    {
+        return $this->render() . 'A';
     }
 }

--- a/src/CriteriaCompo.php
+++ b/src/CriteriaCompo.php
@@ -4,6 +4,7 @@ namespace Imponeer\Database\Criteria;
 
 use Exception;
 use Imponeer\Database\Criteria\Enum\Condition;
+use IteratorAggregate;
 use Traversable;
 
 /**
@@ -11,10 +12,10 @@ use Traversable;
  *
  * @package Imponeer\Database\Criteria
  */
-class CriteriaCompo extends CriteriaElement implements \IteratorAggregate
+class CriteriaCompo extends CriteriaElement implements IteratorAggregate
 {
     /**
-     * @var array<CriteriaElement,string>[]
+     * @var array<array{0: CriteriaElement, 1: Condition}>
      */
     protected array $elements = [];
 
@@ -40,6 +41,8 @@ class CriteriaCompo extends CriteriaElement implements \IteratorAggregate
      * @param string|Condition $condition Condition
      *
      * @return $this
+     *
+     * @noinspection MethodShouldBeFinalInspection
      */
     public function add(CriteriaElement $criteriaElement, Condition|string $condition = Condition::AND): self
     {
@@ -55,6 +58,8 @@ class CriteriaCompo extends CriteriaElement implements \IteratorAggregate
      * @inheritDoc
      *
      * @throws Exception
+     *
+     * @noinspection MethodShouldBeFinalInspection
      */
     public function getBindData(): array
     {
@@ -71,6 +76,8 @@ class CriteriaCompo extends CriteriaElement implements \IteratorAggregate
      * @inheritDoc
      *
      * @return Traversable<string, CriteriaElement>
+     *
+     * @noinspection MethodShouldBeFinalInspection
      */
     public function getIterator(): Traversable
     {
@@ -83,6 +90,8 @@ class CriteriaCompo extends CriteriaElement implements \IteratorAggregate
      * @inheritDoc
      *
      * @throws Exception
+     *
+     * @noinspection MethodShouldBeFinalInspection
      */
     public function render(bool $withBindVariables = false): ?string
     {

--- a/src/CriteriaElement.php
+++ b/src/CriteriaElement.php
@@ -2,12 +2,12 @@
 
 namespace Imponeer\Database\Criteria;
 
-use Imponeer\Database\Criteria\Exceptions\UnsupportedOrderException;
 use Imponeer\Database\Criteria\Traits\GroupByTrait;
 use Imponeer\Database\Criteria\Traits\OrderByTrait;
 use Imponeer\Database\Criteria\Traits\PartialResultsTrait;
 use Imponeer\Database\Criteria\Traits\RenderingTrait;
 use Imponeer\Database\Criteria\Traits\SortByTrait;
+use ValueError;
 
 /**
  * Defines base criteria element
@@ -33,22 +33,16 @@ abstract class CriteriaElement
      *
      * @return mixed
      */
-    public function __get($name)
+    public function __get(string $name): mixed
     {
-        switch ($name) {
-            case 'order':
-                return (string)$this->getOrder();
-            case 'sort':
-                return $this->getSort();
-            case 'limit':
-                return $this->getLimit();
-            case 'start':
-                return $this->getStart();
-            case 'groupBy':
-                /** @noinspection SpellCheckingInspection */
-            case 'groupby':
-                return $this->getGroupBy();
-        }
+        return match ($name) {
+            'order' => $this->getOrder()->value,
+            'sort' => $this->getSort(),
+            'limit' => $this->getLimit(),
+            'start' => $this->getStart(),
+            'groupBy', 'groupby' => $this->getGroupBy(),
+            default => throw new ValueError('Unknown property: ' . $name),
+        };
     }
 
     /**
@@ -60,7 +54,7 @@ abstract class CriteriaElement
      *
      * @return mixed
      */
-    public function __set($name, $value)
+    public function __set(string $name, mixed $value)
     {
         switch ($name) {
             case 'order':
@@ -93,21 +87,13 @@ abstract class CriteriaElement
      */
     public function __isset($name)
     {
-        switch ($name) {
-            case 'order':
-                return $this->getOrder() !== null;
-            case 'sort':
-                return !empty($this->getSort());
-            case 'limit':
-                return !empty($this->getLimit());
-            case 'start':
-                return !empty($this->getStart());
-            case 'groupBy':
-                /** @noinspection SpellCheckingInspection */
-            case 'groupby':
-                return !empty($this->getGroupBy());
-            default:
-                return false;
-        }
+        return match ($name) {
+            'order' => $this->getOrder() !== null,
+            'sort' => !empty($this->getSort()),
+            'limit' => !empty($this->getLimit()),
+            'start' => !empty($this->getStart()),
+            'groupBy', 'groupby' => !empty($this->getGroupBy()),
+            default => false,
+        };
     }
 }

--- a/src/CriteriaElement.php
+++ b/src/CriteriaElement.php
@@ -7,6 +7,8 @@ use Imponeer\Database\Criteria\Traits\OrderByTrait;
 use Imponeer\Database\Criteria\Traits\PartialResultsTrait;
 use Imponeer\Database\Criteria\Traits\RenderingTrait;
 use Imponeer\Database\Criteria\Traits\SortByTrait;
+use JsonSerializable;
+use Stringable;
 use ValueError;
 
 /**
@@ -14,7 +16,7 @@ use ValueError;
  *
  * @package Imponeer\Database\Criteria
  */
-abstract class CriteriaElement
+abstract class CriteriaElement implements Stringable
 {
     use GroupByTrait, OrderByTrait, PartialResultsTrait, RenderingTrait, SortByTrait;
 

--- a/src/CriteriaElement.php
+++ b/src/CriteriaElement.php
@@ -28,12 +28,8 @@ abstract class CriteriaElement
     /**
      * For compatibility. Probably will be removed in feature
      * Gets variable value
-     *
-     * @param string $name Variable name
-     *
-     * @return mixed
      */
-    public function __get(string $name): mixed
+    public function __get(string $name): string|int
     {
         return match ($name) {
             'order' => $this->getOrder()->value,
@@ -46,15 +42,10 @@ abstract class CriteriaElement
     }
 
     /**
-     * For compatibility. Probably will be removed in feature
+     * For compatibility. Probably will be removed in the feature
      * Sets variable
-     *
-     * @param string $name Variable name
-     * @param mixed $value Variable value
-     *
-     * @return mixed
      */
-    public function __set(string $name, mixed $value)
+    public function __set(string $name, mixed $value): void
     {
         switch ($name) {
             case 'order':
@@ -79,13 +70,9 @@ abstract class CriteriaElement
 
     /**
      * For compatibility. Probably will be removed in feature
-     * Checks if variable value is set
-     *
-     * @param string $name Variable name
-     *
-     * @return mixed
+     * Checks if a variable value is set
      */
-    public function __isset($name)
+    public function __isset(string $name): bool
     {
         return match ($name) {
             'order' => $this->getOrder() !== null,

--- a/src/CriteriaItem.php
+++ b/src/CriteriaItem.php
@@ -3,7 +3,11 @@
 namespace Imponeer\Database\Criteria;
 
 use Imponeer\Database\Criteria\Enum\ComparisionOperator;
+use Imponeer\Database\Criteria\Enum\Order;
 use Imponeer\Database\Criteria\Helpers\UniqueBindParam;
+use JsonException;
+use PHPUnit\Framework\Constraint\Operator;
+use Stringable;
 
 /**
  * Defines single Criteria item
@@ -13,68 +17,52 @@ use Imponeer\Database\Criteria\Helpers\UniqueBindParam;
 class CriteriaItem extends CriteriaElement
 {
 
-    /**
-     * @var    string|null
-     */
-    protected $prefix = null;
-
-    /**
-     * @var string|null
-     */
-    protected $function = null;
-
-    /**
-     * @var string|null
-     */
-    protected $column = null;
-
-    /**
-     * @var ComparisionOperator
-     */
-    protected $operator;
+    protected ?string $prefix = null;
+    protected ?string $function = null;
+    protected ?string $column = null;
+    protected ComparisionOperator $operator;
 
     /**
      * Data for criteria item
      *
      * @var array
      */
-    protected $data = [];
+    protected array $data = [];
 
     /**
      * Constructor
      *
      * @param string $column
-     * @param mixed $value
-     * @param string $operator
-     * @param string $prefix
-     * @param string $function
+     * @param mixed|null $value
+     * @param ComparisionOperator|string $operator
+     * @param string|null $prefix
+     * @param string|null $function
      */
-    public function __construct($column, $value = null, $operator = '=', ?string $prefix = null, ?string $function = null)
+    public function __construct(
+        string $column,
+        mixed $value = null,
+        ComparisionOperator|string $operator = '=',
+        ?string $prefix = null,
+        ?string $function = null
+    )
     {
         parent::__construct();
 
         $this->prefix = $prefix;
         $this->function = $function;
         $this->column = $column;
+        $this->operator = $operator instanceof ComparisionOperator ? $operator : ComparisionOperator::from(strtoupper(trim($operator)));
 
-        if ($operator instanceof ComparisionOperator) {
-            $this->operator = $operator;
+        if (is_string($value) && str_starts_with($value, '(')) {
+            $this->data[] = $value;
         } else {
-            $operator = strtoupper(trim($operator));
-            ComparisionOperator::assertValidValue($operator);
-            $this->operator = ComparisionOperator::from($operator);
-        }
-
-        if (is_string($value) && strpos($value, '(') === 0) {
-            $this->data = $value;
-        } else {
-            if (is_array($value) && in_array($this->operator->getValue(), [
+            if (is_array($value) && in_array($this->operator->value, [
                     ComparisionOperator::IS_NOT_NULL,
                     ComparisionOperator::IS_NULL,
                     ComparisionOperator::BETWEEN,
                     ComparisionOperator::NOT_BETWEEN,
                 ], true)) {
-                $this->operator = ComparisionOperator::IS_NULL();
+                $this->operator = ComparisionOperator::IS_NULL;
             }
 
             if (is_array($value)) {
@@ -88,6 +76,11 @@ class CriteriaItem extends CriteriaElement
                 ];
             }
         }
+    }
+
+    public function getComparisionOperator(): ComparisionOperator
+    {
+        return $this->operator;
     }
 
     /**
@@ -106,32 +99,32 @@ class CriteriaItem extends CriteriaElement
             $clause = sprintf($this->function, $clause);
         }
 
-        switch ($this->operator->getValue()) {
+        switch ($this->operator->value) {
             case ComparisionOperator::IS_NOT_NULL:
             case ComparisionOperator::IS_NULL:
-                $clause .= ' ' . $this->operator;
+                $clause .= ' ' . $this->operator->value;
                 break;
             case ComparisionOperator::BETWEEN:
             case ComparisionOperator::NOT_BETWEEN:
                 if ($withBindVariables) {
                     [$fromValue, $toValue] = array_keys($this->data);
-                    $clause .= sprintf(" %s %d AND %d", $this->operator, (int)$fromValue, (int)$toValue);
+                    $clause .= sprintf(" %s %d AND %d", $this->operator->value, (int)$fromValue, (int)$toValue);
                 } else {
                     [$fromKey, $toKey] = array_keys($this->data);
-                    $clause .= sprintf(" %s :%s AND :%s", $this->operator, $fromKey, $toKey);
+                    $clause .= sprintf(" %s :%s AND :%s", $this->operator->value, $fromKey, $toKey);
                 }
                 break;
             case ComparisionOperator::IN:
             case ComparisionOperator::NOT_IN:
                 if (is_string($this->data)) {
-                    $clause .= ' ' . $this->operator . $this->data;
+                    $clause .= ' ' . $this->operator->value . $this->data;
                     break;
                 }
                 if (empty($this->data)) {
-                    $clause .= ' ' . ($this->operator->getValue() === ComparisionOperator::IN ? ' IS 0 ' : ' IS 1 ');
+                    $clause .= ' ' . ($this->operator === ComparisionOperator::IN ? ' IS 0 ' : ' IS 1 ');
                     break;
                 }
-                $clause .= ' ' . $this->operator . '(';
+                $clause .= ' ' . $this->operator->value . '(';
                 if ($withBindVariables) {
                     foreach (array_values($this->data) as $i => $value) {
                         if ($i !== 0) {
@@ -151,9 +144,9 @@ class CriteriaItem extends CriteriaElement
                 break;
             default:
                 if ($withBindVariables) {
-                    $clause .= sprintf(" %s %s", $this->operator, $this->prepareRenderedValue(current($this->data)));
+                    $clause .= sprintf(" %s %s", $this->operator->value, $this->prepareRenderedValue(current($this->data)));
                 } else {
-                    $clause .= sprintf(" %s :%s", $this->operator, key($this->data));
+                    $clause .= sprintf(" %s :%s", $this->operator->value, key($this->data));
                 }
         }
 
@@ -166,8 +159,10 @@ class CriteriaItem extends CriteriaElement
      * @param null|bool|object|string|float $value Value to make as query part
      *
      * @return string
+     *
+     * @throws JsonException
      */
-    protected function prepareRenderedValue($value)
+    protected function prepareRenderedValue(null|bool|object|string|float|array $value)
     {
         if ($value === null) {
             return 'NULL';
@@ -178,7 +173,7 @@ class CriteriaItem extends CriteriaElement
         }
 
         if (is_object($value)) {
-            if (method_exists($value, '__toString') || (interface_exists('\\Stringable') && ($value instanceof \Stringable))) {
+            if ((interface_exists(Stringable::class) && ($value instanceof Stringable)) || method_exists($value, '__toString')) {
                 return $this->addSlashes((string)$value);
             }
 
@@ -186,14 +181,14 @@ class CriteriaItem extends CriteriaElement
         }
 
         if (is_array($value)) {
-            return json_encode($value);
+            return json_encode($value, JSON_THROW_ON_ERROR);
         }
 
         if ($value === '') {
             return "''";
         }
 
-        if ((strpos($value, '`') !== 0) && (substr($value, -1) !== '`')) {
+        if ((!str_starts_with($value, '`')) && (!str_ends_with($value, '`'))) {
             return $this->addSlashes($value);
         }
 
@@ -217,6 +212,6 @@ class CriteriaItem extends CriteriaElement
      */
     public function getBindData(): array
     {
-        return is_string($this->data) ? [] : $this->data;
+        return $this->data;
     }
 }

--- a/src/CriteriaItem.php
+++ b/src/CriteriaItem.php
@@ -226,4 +226,12 @@ class CriteriaItem extends CriteriaElement
                 ComparisonOperator::NOT_BETWEEN,
             ], true);
     }
+
+    /**
+     * @throws JsonException
+     */
+    public function __toString(): string
+    {
+        return $this->render();
+    }
 }

--- a/src/Enum/ComparisionOperator.php
+++ b/src/Enum/ComparisionOperator.php
@@ -2,122 +2,101 @@
 
 namespace Imponeer\Database\Criteria\Enum;
 
-use MyCLabs\Enum\Enum;
-
 /**
- * SQL comparision operator
+ * SQL comparison operator
  *
  * @package Imponeer\Database\Criteria\Enum
- *
- * @method static ComparisionOperator IS_NULL()
- * @method static ComparisionOperator IS_NOT_NULL()
- * @method static ComparisionOperator IN()
- * @method static ComparisionOperator NOT_IN()
- * @method static ComparisionOperator GREATER_THAN()
- * @method static ComparisionOperator GREATER_OR_EQUAL_TO()
- * @method static ComparisionOperator LESS_THAN()
- * @method static ComparisionOperator LESS_OR_EQUAL_TO()
- * @method static ComparisionOperator EQUAL_TO()
- * @method static ComparisionOperator NOT_EQUAL_TO()
- * @method static ComparisionOperator BETWEEN()
- * @method static ComparisionOperator LIKE()
- * @method static ComparisionOperator NULL_SAFE_EQUAL_TO()
- * @method static ComparisionOperator NOT_BETWEEN()
- * @method static ComparisionOperator NOT_LIKE()
- * @method static ComparisionOperator NOT_REGEXP()
- * @method static ComparisionOperator REGEXP()
- * @method static ComparisionOperator RLIKE()
  */
-class ComparisionOperator extends Enum
+enum ComparisionOperator: string
 {
 
     /**
      * NULL value test
      */
-    public const IS_NULL = 'IS NULL';
+    case IS_NULL = 'IS NULL';
 
     /**
      * NOT NULL value test
      */
-    public const IS_NOT_NULL = 'IS NOT NULL';
+    case IS_NOT_NULL = 'IS NOT NULL';
 
     /**
      * Whether a value is within a set of values
      */
-    public const IN = 'IN';
+    case IN = 'IN';
 
     /**
      * Whether a value is not within a set of values
      */
-    public const NOT_IN = 'NOT IN';
+    case NOT_IN = 'NOT IN';
 
     /**
      * Greater than operator
      */
-    public const GREATER_THAN = '>';
+    case GREATER_THAN = '>';
 
     /**
      * Greater than or equal operator
      */
-    public const GREATER_OR_EQUAL_TO = '>=';
+    case GREATER_OR_EQUAL_TO = '>=';
 
     /**
      * Less than or equal operator
      */
-    public const LESS_THAN = '<';
+    case LESS_THAN = '<';
 
     /**
      * Less than or equal operator
      */
-    public const LESS_OR_EQUAL_TO = '<=';
+    case LESS_OR_EQUAL_TO = '<=';
 
     /**
      * Equal operator
      */
-    public const EQUAL_TO = '=';
+    case EQUAL_TO = '=';
 
     /**
      * Not equal operator
      */
-    public const NOT_EQUAL_TO = '!=';
+    case NOT_EQUAL_TO = '!=';
 
     /**
      * Whether a value is within a range of values
      */
-    public const BETWEEN = 'BETWEEN';
+    case BETWEEN = 'BETWEEN';
 
     /**
      * Simple pattern matching
      */
-    public const LIKE = 'LIKE';
+    case LIKE = 'LIKE';
 
     /**
      * NULL-safe equal to operator
      */
-    public const NULL_SAFE_EQUAL_TO = '<=>';
+    case NULL_SAFE_EQUAL_TO = '<=>';
 
     /**
      *    Whether a value is not within a range of values
      */
-    public const NOT_BETWEEN = 'NOT BETWEEN';
+    case NOT_BETWEEN = 'NOT BETWEEN';
 
     /**
      *    Negation of simple pattern matching
      */
-    public const NOT_LIKE = 'NOT LIKE';
+    case NOT_LIKE = 'NOT LIKE';
 
     /**
      * Negation of REGEXP
      */
-    public const NOT_REGEXP = 'NOT REGEXP';
+    case NOT_REGEXP = 'NOT REGEXP';
 
     /**
      * REGEXP match
      */
-    public const REGEXP = 'REGEXP';
+    case REGEXP = 'REGEXP';
 
     /**
      * Whether string matches regular expression
      */
-    public const RLIKE = 'RLIKE';
+    case RLIKE = 'RLIKE';
 }

--- a/src/Enum/ComparisonOperator.php
+++ b/src/Enum/ComparisonOperator.php
@@ -7,7 +7,7 @@ namespace Imponeer\Database\Criteria\Enum;
  *
  * @package Imponeer\Database\Criteria\Enum
  */
-enum ComparisionOperator: string
+enum ComparisonOperator: string
 {
 
     /**

--- a/src/Enum/Condition.php
+++ b/src/Enum/Condition.php
@@ -2,33 +2,27 @@
 
 namespace Imponeer\Database\Criteria\Enum;
 
-use MyCLabs\Enum\Enum;
-
 /**
  * Rules how to join where parts
  *
  * @package Imponeer\Database\Criteria\Enum
- *
- * @method static Condition AND ();
- * @method static Condition OR ();
- * @method static Condition XOR ();
  */
-class Condition extends Enum
+enum Condition: string
 {
 
     /**
      * Use AND
      */
-    private const AND = 'AND';
+    case AND = 'AND';
 
     /**
      * Use OR
      */
-    private const OR = 'OR';
+    case OR = 'OR';
 
     /**
      * Use XOR
      */
-    private const XOR = 'XOR';
+    case XOR = 'XOR';
 
 }

--- a/src/Enum/Order.php
+++ b/src/Enum/Order.php
@@ -2,27 +2,23 @@
 
 namespace Imponeer\Database\Criteria\Enum;
 
-use MyCLabs\Enum\Enum;
 
 /**
  * Defines how to order results
  *
  * @package Imponeer\Database\Criteria\Enum
- *
- * @method static Order ASC()
- * @method static Order DESC()
  */
-final class Order extends Enum
+enum Order: string
 {
 
     /**
      * Sort in ASC mode
      */
-    private const ASC = 'ASC';
+    case ASC = 'ASC';
 
     /**
      * Sort in DESC mode
      */
-    private const DESC = 'DESC';
+    case DESC = 'DESC';
 
 }

--- a/src/Helpers/UniqueBindParam.php
+++ b/src/Helpers/UniqueBindParam.php
@@ -11,10 +11,8 @@ final class UniqueBindParam
 {
     /**
      * Last generated bind suffix ID
-     *
-     * @var int
      */
-    static private $lastGeneratedBindSuffixId = 0;
+    static private int $lastGeneratedBindSuffixId = 0;
 
     /**
      * UniqueBindParam constructor.

--- a/src/Helpers/UniqueBindParam.php
+++ b/src/Helpers/UniqueBindParam.php
@@ -25,8 +25,6 @@ final class UniqueBindParam
      * Generates unique bind name from column name
      *
      * @param string $column Column name
-     *
-     * @return string
      */
     public static function generate(string $column): string
     {

--- a/src/Traits/GroupByTrait.php
+++ b/src/Traits/GroupByTrait.php
@@ -14,9 +14,8 @@ trait GroupByTrait
     /**
      * Sets group by
      *
-     * @param string $group
-     *
-     * @return self
+     * @noinspection MethodShouldBeFinalInspection
+     * @noinspection PhpDocSignatureInspection
      */
     public function setGroupBy(string $group): self
     {
@@ -28,7 +27,7 @@ trait GroupByTrait
     /**
      * Gets a group by value
      *
-     * @return    string
+     * @noinspection MethodShouldBeFinalInspection
      */
     public function getGroupBy(): string
     {

--- a/src/Traits/GroupByTrait.php
+++ b/src/Traits/GroupByTrait.php
@@ -9,10 +9,7 @@ namespace Imponeer\Database\Criteria\Traits;
  */
 trait GroupByTrait
 {
-    /**
-     * @var null|string
-     */
-    protected $group = null;
+    protected ?string $group = null;
 
     /**
      * Sets group by
@@ -21,7 +18,7 @@ trait GroupByTrait
      *
      * @return self
      */
-    public function setGroupBy($group): self
+    public function setGroupBy(string $group): self
     {
         $this->group = $group;
 
@@ -29,7 +26,7 @@ trait GroupByTrait
     }
 
     /**
-     * Gets group by value
+     * Gets a group by value
      *
      * @return    string
      */

--- a/src/Traits/OrderByTrait.php
+++ b/src/Traits/OrderByTrait.php
@@ -14,17 +14,15 @@ trait OrderByTrait
 
     /**
      * Sort order
-     *
-     * @var    Order
      */
-    protected $order;
+    protected Order $order;
 
     /**
      * OrderByTrait constructor.
      */
     public function __construct()
     {
-        $this->order = Order::ASC();
+        $this->order = Order::ASC;
     }
 
     /**
@@ -44,15 +42,9 @@ trait OrderByTrait
      *
      * @return self
      */
-    public function setOrder($order): self
+    public function setOrder(Order|string $order): self
     {
-        if ($order instanceof Order) {
-            $this->order = $order;
-        } else {
-            $order = strtoupper(trim($order));
-            Order::assertValidValue($order);
-            $this->order = Order::from($order);
-        }
+        $this->order = $order instanceof Order ? $order : Order::from(strtoupper(trim($order)));
 
         return $this;
     }

--- a/src/Traits/OrderByTrait.php
+++ b/src/Traits/OrderByTrait.php
@@ -12,23 +12,15 @@ use Imponeer\Database\Criteria\Enum\Order;
 trait OrderByTrait
 {
 
-    /**
-     * Sort order
-     */
     protected Order $order;
 
-    /**
-     * OrderByTrait constructor.
-     */
     public function __construct()
     {
         $this->order = Order::ASC;
     }
 
     /**
-     * Gets order
-     *
-     * @return    Order
+     * @noinspection MethodShouldBeFinalInspection
      */
     public function getOrder(): Order
     {
@@ -40,7 +32,7 @@ trait OrderByTrait
      *
      * @param string|Order $order Order to set for this criteria element
      *
-     * @return self
+     * @noinspection MethodShouldBeFinalInspection
      */
     public function setOrder(Order|string $order): self
     {

--- a/src/Traits/PartialResultsTrait.php
+++ b/src/Traits/PartialResultsTrait.php
@@ -16,8 +16,8 @@ trait PartialResultsTrait
     /**
      * Gets how many results to return
      *
-     * @return    int
-     */
+     * @noinspection MethodShouldBeFinalInspection
+     **/
     public function getLimit(): int
     {
         return $this->limit;
@@ -28,7 +28,7 @@ trait PartialResultsTrait
      *
      * @param int $limit Limit for results
      *
-     * @return self
+     * @noinspection MethodShouldBeFinalInspection
      */
     public function setLimit(int $limit = 0): self
     {
@@ -40,7 +40,8 @@ trait PartialResultsTrait
     /**
      * Gets from what record number to return results (counting starts from 0)
      *
-     * @return    int
+     * @noinspection MethodShouldBeFinalInspection
+     * @noinspection PhpDocSignatureInspection
      */
     public function getStart(): int
     {
@@ -52,7 +53,8 @@ trait PartialResultsTrait
      *
      * @param int $start Sets start position
      *
-     * @return self
+     * @noinspection MethodShouldBeFinalInspection
+     * @noinspection PhpDocSignatureInspection
      */
     public function setStart(int $start = 0): self
     {

--- a/src/Traits/PartialResultsTrait.php
+++ b/src/Traits/PartialResultsTrait.php
@@ -10,15 +10,8 @@ namespace Imponeer\Database\Criteria\Traits;
 trait PartialResultsTrait
 {
 
-    /**
-     * @var    int
-     */
-    protected $limit = 0;
-
-    /**
-     * @var    int
-     */
-    protected $start = 0;
+    protected int $limit = 0;
+    protected int $start = 0;
 
     /**
      * Gets how many results to return
@@ -37,9 +30,9 @@ trait PartialResultsTrait
      *
      * @return self
      */
-    public function setLimit($limit = 0): self
+    public function setLimit(int $limit = 0): self
     {
-        $this->limit = (int)$limit;
+        $this->limit = $limit;
 
         return $this;
     }

--- a/src/Traits/RenderingTrait.php
+++ b/src/Traits/RenderingTrait.php
@@ -15,7 +15,7 @@ trait RenderingTrait
      *
      * @param bool $withBinds Render with bind variables
      *
-     * @return    string
+     * @noinspection MethodShouldBeFinalInspection
      */
     public function renderWhere(bool $withBinds = false): string
     {
@@ -27,8 +27,6 @@ trait RenderingTrait
      * Render the criteria string
      *
      * @param bool $withBindVariables Render with bind variables
-     *
-     * @return string|null
      */
     abstract public function render(bool $withBindVariables = false): ?string;
 

--- a/src/Traits/SortByTrait.php
+++ b/src/Traits/SortByTrait.php
@@ -2,6 +2,8 @@
 
 namespace Imponeer\Database\Criteria\Traits;
 
+use Imponeer\Database\Criteria\CriteriaElement;
+
 /**
  * Trait for setting fields for sorting results
  *
@@ -10,10 +12,7 @@ namespace Imponeer\Database\Criteria\Traits;
 trait SortByTrait
 {
 
-    /**
-     * @var    string|null
-     */
-    protected $sort = null;
+    protected ?string $sort = null;
 
     /**
      * Gets sort field
@@ -28,9 +27,9 @@ trait SortByTrait
     /**
      * Sets sort field
      *
-     * @param string $sort Database field name for sorting
+     * @param string|null $sort Database field name for sorting
      *
-     * @return self
+     * @return SortByTrait|CriteriaElement
      */
     public function setSort(?string $sort): self
     {

--- a/src/Traits/SortByTrait.php
+++ b/src/Traits/SortByTrait.php
@@ -2,8 +2,6 @@
 
 namespace Imponeer\Database\Criteria\Traits;
 
-use Imponeer\Database\Criteria\CriteriaElement;
-
 /**
  * Trait for setting fields for sorting results
  *
@@ -17,7 +15,7 @@ trait SortByTrait
     /**
      * Gets sort field
      *
-     * @return    string
+     * @noinspection MethodShouldBeFinalInspection
      */
     public function getSort(): string
     {
@@ -29,7 +27,7 @@ trait SortByTrait
      *
      * @param string|null $sort Database field name for sorting
      *
-     * @return SortByTrait|CriteriaElement
+     * @noinspection MethodShouldBeFinalInspection
      */
     public function setSort(?string $sort): self
     {

--- a/tests/CriteriaCompoTest.php
+++ b/tests/CriteriaCompoTest.php
@@ -8,6 +8,7 @@ use Imponeer\Database\Criteria\CriteriaCompo;
 use Imponeer\Database\Criteria\CriteriaItem;
 use Imponeer\Database\Criteria\Enum\Condition;
 use Imponeer\Database\Criteria\Enum\Order;
+use JsonException;
 use PHPUnit\Framework\TestCase;
 use Random\RandomException;
 
@@ -16,11 +17,15 @@ class CriteriaCompoTest extends TestCase
     /**
      * Provides Condition test data
      *
-     * @return Generator
+     * @return array<string, array{0: CriteriaCompo, 1: string|Condition}>
+     *
      * @throws RandomException
+     * @throws JsonException
      */
-    final public function provideCondition(): Generator
+    final public function provideCondition(): array
     {
+        $testsVariations = [];
+
         foreach (Condition::cases() as $conditionData) {
             $condition = $conditionData->value;
             foreach ([$condition, ' ' . $condition . ' ', strtolower($condition), ucfirst(strtolower($condition))] as $conditionVar) {
@@ -28,25 +33,31 @@ class CriteriaCompoTest extends TestCase
                 $compo1 = new CriteriaCompo();
                 $compo1->add(new CriteriaItem(sha1(random_int(PHP_INT_MIN, PHP_INT_MAX))));
                 $compo1->add(new CriteriaItem(sha1(random_int(PHP_INT_MIN, PHP_INT_MAX))), $conditionVar);
-                yield [$compo1, $conditionVar];
+                $label = sprintf('Two columns with null values and condition %s', $conditionData->name);
+                $testsVariations[$label] = [$compo1, $conditionVar];
 
                 // 2nd variant for compo
                 $compo2 = new CriteriaCompo(new CriteriaItem(sha1(random_int(PHP_INT_MIN, PHP_INT_MAX))));
                 $compo2->add(new CriteriaItem(sha1(random_int(PHP_INT_MIN, PHP_INT_MAX))), $conditionVar);
-                yield [$compo2, $conditionVar];
+                $label = sprintf("One column with null value and condition %s", $conditionData->name);
+                $testsVariations[$label] = [$compo2, $conditionVar];
 
                 // 3nd variant for compo
                 $compo3 = new CriteriaCompo();
                 $compo3->add($compo1);
                 $compo3->add($compo2, $conditionVar);
-                yield [$compo3, $conditionVar];
+                $label = sprintf('Joined two criteria with condition %s', $conditionData->name);
+                $testsVariations[$label] = [$compo3, $conditionVar];
 
                 // 4nd variant for compo
                 $compo4 = new CriteriaCompo($compo1);
                 $compo4->add($compo2, $conditionVar);
-                yield [$compo4, $conditionVar];
+                $label = sprintf('Appended two criteria with condition %s', $conditionData->name);
+                $testsVariations[$label] = [$compo4, $conditionVar];
             }
         }
+
+        return $testsVariations;
     }
 
     /**
@@ -106,10 +117,10 @@ class CriteriaCompoTest extends TestCase
     final public function provideOrder(): Generator
     {
         foreach (Order::cases() as $order) {
-            yield [$order->value];
-            yield [strtolower($order->value)];
-            yield [ucfirst(strtolower($order->value))];
-            yield [' ' . $order->value . ' '];
+            yield $order->name => [$order->value];
+            yield strtolower($order->value) => [strtolower($order->value)];
+            yield ucfirst(strtolower($order->value)) => [ucfirst(strtolower($order->value))];
+            yield ' ' . $order->value . ' ' => [' ' . $order->value . ' '];
         }
     }
 

--- a/tests/CriteriaCompoTest.php
+++ b/tests/CriteriaCompoTest.php
@@ -19,7 +19,7 @@ class CriteriaCompoTest extends TestCase
      * @return Generator
      * @throws RandomException
      */
-    public function provideCondition()
+    final public function provideCondition(): Generator
     {
         foreach (Condition::cases() as $conditionData) {
             $condition = $conditionData->value;
@@ -59,7 +59,7 @@ class CriteriaCompoTest extends TestCase
      *
      * @throws Exception
      */
-    public function testCondition(CriteriaCompo $compo, string|Condition $condition): void
+    final public function testCondition(CriteriaCompo $compo, string|Condition $condition): void
     {
         if (is_string($condition)) {
             $condition = Condition::from(strtoupper(trim($condition)));
@@ -88,7 +88,7 @@ class CriteriaCompoTest extends TestCase
      *
      * @throws Exception
      */
-    public function testEmptyRender(): void
+    final public function testEmptyRender(): void
     {
         $criteria = new CriteriaCompo();
         self::assertEmpty($criteria->render(false), 'Should render empty string (without binding)');
@@ -103,7 +103,7 @@ class CriteriaCompoTest extends TestCase
      *
      * @return Generator
      */
-    public function provideOrder(): Generator
+    final public function provideOrder(): Generator
     {
         foreach (Order::cases() as $order) {
             yield [$order->value];
@@ -120,7 +120,7 @@ class CriteriaCompoTest extends TestCase
      *
      * @dataProvider provideOrder
      */
-    public function testOrder(Order|string $order): void
+    final public function testOrder(Order|string $order): void
     {
         $criteria = new CriteriaCompo();
         self::assertSame(Order::ASC->value, $criteria->getOrder()->value, 'Default order is not correct');
@@ -133,7 +133,7 @@ class CriteriaCompoTest extends TestCase
      *
      * @throws RandomException
      */
-    public function testGroupBy()
+    final public function testGroupBy(): void
     {
         $criteria = new CriteriaCompo();
         self::assertEmpty($criteria->getGroupBy(), 'Default group by is not empty');
@@ -149,7 +149,7 @@ class CriteriaCompoTest extends TestCase
      *
      * @throws RandomException
      */
-    public function testSortBy(): void
+    final public function testSortBy(): void
     {
         $criteria = new CriteriaCompo();
         self::assertEmpty($criteria->getSort(), 'Default sort by is not empty');
@@ -164,7 +164,7 @@ class CriteriaCompoTest extends TestCase
      *
      * @throws RandomException
      */
-    public function testPartialResults(): void
+    final public function testPartialResults(): void
     {
         $criteria = new CriteriaCompo();
         self::assertSame(0, $criteria->getLimit(), 'Default limit is not 0');

--- a/tests/CriteriaItemTest.php
+++ b/tests/CriteriaItemTest.php
@@ -4,8 +4,9 @@ namespace Imponeer\Tests\Database\Criteria;
 
 use Generator;
 use Imponeer\Database\Criteria\CriteriaItem;
-use Imponeer\Database\Criteria\Enum\ComparisionOperator;
+use Imponeer\Database\Criteria\Enum\ComparisonOperator;
 use Imponeer\Database\Criteria\Enum\Order;
+use JsonException;
 use PHPUnit\Framework\TestCase;
 use Random\RandomException;
 use stdClass;
@@ -19,14 +20,14 @@ class CriteriaItemTest extends TestCase
      * @return Generator
      * @throws RandomException
      */
-    public function provideComparisionOperators(): Generator
+    final public function provideComparisionOperators(): Generator
     {
         $column = sha1(random_int(PHP_INT_MIN, PHP_INT_MAX));
         $specialOperators = [
-            ComparisionOperator::BETWEEN->name,
-            ComparisionOperator::NOT_BETWEEN->name,
-            ComparisionOperator::IN->name,
-            ComparisionOperator::NOT_IN->name,
+            ComparisonOperator::BETWEEN->name,
+            ComparisonOperator::NOT_BETWEEN->name,
+            ComparisonOperator::IN->name,
+            ComparisonOperator::NOT_IN->name,
         ];
         $possibleValues = [
             null,  // null value
@@ -38,7 +39,7 @@ class CriteriaItemTest extends TestCase
             new stdClass(), // class
         ];
 
-        foreach (ComparisionOperator::cases() as $operatorEnum) {
+        foreach (ComparisonOperator::cases() as $operatorEnum) {
             if (in_array($operatorEnum->name, $specialOperators, true)) {
                 continue;
             }
@@ -54,7 +55,7 @@ class CriteriaItemTest extends TestCase
             }
         }
 
-        foreach ([ComparisionOperator::BETWEEN, ComparisionOperator::NOT_BETWEEN] as $operatorEnum) {
+        foreach ([ComparisonOperator::BETWEEN, ComparisonOperator::NOT_BETWEEN] as $operatorEnum) {
             yield [$column, [random_int(PHP_INT_MIN, 0), random_int(1, PHP_INT_MAX)], $operatorEnum];
             $operatorVal = $operatorEnum->value;
             yield [$column, [random_int(PHP_INT_MIN, 0), random_int(1, PHP_INT_MAX)], $operatorVal];
@@ -63,7 +64,7 @@ class CriteriaItemTest extends TestCase
             yield [$column, [random_int(PHP_INT_MIN, 0), random_int(1, PHP_INT_MAX)], ucfirst(strtolower($operatorVal))];
         }
 
-        foreach ([ComparisionOperator::IN, ComparisionOperator::NOT_IN] as $operatorEnum) {
+        foreach ([ComparisonOperator::IN, ComparisonOperator::NOT_IN] as $operatorEnum) {
             foreach ($possibleValues as $value) {
                 yield [$column, array_fill(0, random_int(1, 100), $value), $operatorEnum];
                 $operatorVal = $operatorEnum->value;
@@ -80,28 +81,30 @@ class CriteriaItemTest extends TestCase
      *
      * @param string $column Column name
      * @param mixed $value Value to use
-     * @param string|ComparisionOperator $operator Comparison operator to be used for test
+     * @param string|ComparisonOperator $operator Comparison operator to be used for test
      *
      * @dataProvider provideComparisionOperators
+     *
+     * @throws JsonException
      */
-    public function testIfOperatorRendersContent(string $column, mixed $value, ComparisionOperator|string $operator): void
+    final public function testIfOperatorRendersContent(string $column, mixed $value, ComparisonOperator|string $operator): void
     {
         $criteria = new CriteriaItem($column, $value, $operator);
         self::assertNotEmpty(
             $criteria->render(false),
-            'Criteria with condition ' . $criteria->getComparisionOperator()->name . ' doesn\'t renders SQL (without binds)'
+            'Criteria with condition ' . $criteria->getComparisonOperator()->name . ' doesn\'t renders SQL (without binds)'
         );
         self::assertNotEmpty(
             $criteria->renderWhere(false),
-            'Criteria with condition ' . $criteria->getComparisionOperator()->name . ' doesn\'t renders WHERE SQL (without binds)'
+            'Criteria with condition ' . $criteria->getComparisonOperator()->name . ' doesn\'t renders WHERE SQL (without binds)'
         );
         self::assertNotEmpty(
             $criteria->render(true),
-            'Criteria with condition ' . $criteria->getComparisionOperator()->name . ' doesn\'t renders SQL (with binds)'
+            'Criteria with condition ' . $criteria->getComparisonOperator()->name . ' doesn\'t renders SQL (with binds)'
         );
         self::assertNotEmpty(
             $criteria->renderWhere(true),
-            'Criteria with condition ' . $criteria->getComparisionOperator()->name . ' doesn\'t renders WHERE SQL (with binds)'
+            'Criteria with condition ' . $criteria->getComparisonOperator()->name . ' doesn\'t renders WHERE SQL (with binds)'
         );
     }
 
@@ -110,7 +113,7 @@ class CriteriaItemTest extends TestCase
      *
      * @return Generator
      */
-    public function provideOrder(): Generator
+    final public function provideOrder(): Generator
     {
         foreach (Order::cases() as $order) {
             yield [$order->value];
@@ -129,7 +132,7 @@ class CriteriaItemTest extends TestCase
      *
      * @throws RandomException
      */
-    public function testOrder(Order|string $order): void
+    final public function testOrder(Order|string $order): void
     {
         $criteria = new CriteriaItem(sha1(random_int(PHP_INT_MIN, PHP_INT_MAX)));
         self::assertSame(Order::ASC->value, $criteria->getOrder()->value, 'Default order is not correct');
@@ -142,7 +145,7 @@ class CriteriaItemTest extends TestCase
      *
      * @throws RandomException
      */
-    public function testGroupBy(): void
+    final public function testGroupBy(): void
     {
         $criteria = new CriteriaItem(sha1(random_int(PHP_INT_MIN, PHP_INT_MAX)));
         self::assertEmpty($criteria->getGroupBy(), 'Default group by is not empty');
@@ -157,7 +160,7 @@ class CriteriaItemTest extends TestCase
      * Tests sort by operations
      * @throws RandomException
      */
-    public function testSortBy(): void
+    final public function testSortBy(): void
     {
         $criteria = new CriteriaItem(sha1(random_int(PHP_INT_MIN, PHP_INT_MAX)));
         self::assertEmpty($criteria->getSort(), 'Default sort by is not empty');
@@ -171,7 +174,7 @@ class CriteriaItemTest extends TestCase
      * Tests limit/from by operations
      * @throws RandomException
      */
-    public function testPartialResults(): void
+    final public function testPartialResults(): void
     {
         $criteria = new CriteriaItem(sha1(random_int(PHP_INT_MIN, PHP_INT_MAX)));
         self::assertSame(0, $criteria->getLimit(), 'Default limit is not 0');

--- a/tests/CriteriaItemTest.php
+++ b/tests/CriteriaItemTest.php
@@ -2,44 +2,47 @@
 
 namespace Imponeer\Tests\Database\Criteria;
 
+use Generator;
 use Imponeer\Database\Criteria\CriteriaItem;
 use Imponeer\Database\Criteria\Enum\ComparisionOperator;
 use Imponeer\Database\Criteria\Enum\Order;
 use PHPUnit\Framework\TestCase;
+use Random\RandomException;
 use stdClass;
 
 class CriteriaItemTest extends TestCase
 {
 
     /**
-     * Gets all possible comparision operators enums
+     * Gets all possible comparison operators enums
      *
      * @return Generator
+     * @throws RandomException
      */
-    public function provideComparisionOperators()
+    public function provideComparisionOperators(): Generator
     {
-        $column = sha1(mt_rand(PHP_INT_MIN, PHP_INT_MAX));
+        $column = sha1(random_int(PHP_INT_MIN, PHP_INT_MAX));
         $specialOperators = [
-            ComparisionOperator::BETWEEN()->getKey(),
-            ComparisionOperator::NOT_BETWEEN()->getKey(),
-            ComparisionOperator::IN()->getKey(),
-            ComparisionOperator::NOT_IN()->getKey(),
+            ComparisionOperator::BETWEEN->name,
+            ComparisionOperator::NOT_BETWEEN->name,
+            ComparisionOperator::IN->name,
+            ComparisionOperator::NOT_IN->name,
         ];
         $possibleValues = [
             null,  // null value
-            md5(mt_rand(PHP_INT_MIN, PHP_INT_MAX)),  // random string
-            mt_rand(PHP_INT_MIN, PHP_INT_MAX), // random int
+            md5(random_int(PHP_INT_MIN, PHP_INT_MAX)),  // random string
+            random_int(PHP_INT_MIN, PHP_INT_MAX), // random int
             mt_rand() / mt_getrandmax(), // random float
             true, // true
             [], // array
             new stdClass(), // class
         ];
 
-        foreach (ComparisionOperator::values() as $operatorEnum) {
-            if (in_array($operatorEnum->getKey(), $specialOperators, true)) {
+        foreach (ComparisionOperator::cases() as $operatorEnum) {
+            if (in_array($operatorEnum->name, $specialOperators, true)) {
                 continue;
             }
-            $operatorVal = $operatorEnum->getValue();
+            $operatorVal = $operatorEnum->value;
             foreach ($possibleValues as $value) {
                 yield [$column, $value, $operatorEnum];
                 yield [$column, $value, $operatorVal];
@@ -51,54 +54,54 @@ class CriteriaItemTest extends TestCase
             }
         }
 
-        foreach ([ComparisionOperator::BETWEEN(), ComparisionOperator::NOT_BETWEEN()] as $operatorEnum) {
-            yield [$column, [mt_rand(PHP_INT_MIN, 0), mt_rand(1, PHP_INT_MAX)], $operatorEnum];
-            $operatorVal = $operatorEnum->getValue();
-            yield [$column, [mt_rand(PHP_INT_MIN, 0), mt_rand(1, PHP_INT_MAX)], $operatorVal];
-            yield [$column, [mt_rand(PHP_INT_MIN, 0), mt_rand(1, PHP_INT_MAX)], ' ' . $operatorVal . ' '];
-            yield [$column, [mt_rand(PHP_INT_MIN, 0), mt_rand(1, PHP_INT_MAX)], strtolower($operatorVal)];
-            yield [$column, [mt_rand(PHP_INT_MIN, 0), mt_rand(1, PHP_INT_MAX)], ucfirst(strtolower($operatorVal))];
+        foreach ([ComparisionOperator::BETWEEN, ComparisionOperator::NOT_BETWEEN] as $operatorEnum) {
+            yield [$column, [random_int(PHP_INT_MIN, 0), random_int(1, PHP_INT_MAX)], $operatorEnum];
+            $operatorVal = $operatorEnum->value;
+            yield [$column, [random_int(PHP_INT_MIN, 0), random_int(1, PHP_INT_MAX)], $operatorVal];
+            yield [$column, [random_int(PHP_INT_MIN, 0), random_int(1, PHP_INT_MAX)], ' ' . $operatorVal . ' '];
+            yield [$column, [random_int(PHP_INT_MIN, 0), random_int(1, PHP_INT_MAX)], strtolower($operatorVal)];
+            yield [$column, [random_int(PHP_INT_MIN, 0), random_int(1, PHP_INT_MAX)], ucfirst(strtolower($operatorVal))];
         }
 
-        foreach ([ComparisionOperator::IN(), ComparisionOperator::NOT_IN()] as $operatorEnum) {
+        foreach ([ComparisionOperator::IN, ComparisionOperator::NOT_IN] as $operatorEnum) {
             foreach ($possibleValues as $value) {
-                yield [$column, array_fill(0, mt_rand(1, 100), $value), $operatorEnum];
-                $operatorVal = $operatorEnum->getValue();
-                yield [$column, array_fill(0, mt_rand(1, 100), $value), $operatorVal];
-                yield [$column, array_fill(0, mt_rand(1, 100), $value), ' ' . $operatorVal . ' '];
-                yield [$column, array_fill(0, mt_rand(1, 100), $value), strtolower($operatorVal)];
-                yield [$column, array_fill(0, mt_rand(1, 100), $value), ucfirst(strtolower($operatorVal))];
+                yield [$column, array_fill(0, random_int(1, 100), $value), $operatorEnum];
+                $operatorVal = $operatorEnum->value;
+                yield [$column, array_fill(0, random_int(1, 100), $value), $operatorVal];
+                yield [$column, array_fill(0, random_int(1, 100), $value), ' ' . $operatorVal . ' '];
+                yield [$column, array_fill(0, random_int(1, 100), $value), strtolower($operatorVal)];
+                yield [$column, array_fill(0, random_int(1, 100), $value), ucfirst(strtolower($operatorVal))];
             }
         }
     }
 
     /**
-     * Test if all comparision operators can be rendered by enum as object
+     * Test if enum can render all comparison operators as object
      *
      * @param string $column Column name
      * @param mixed $value Value to use
-     * @param ComparisionOperator|string $operator Comparision operator to be used for test
+     * @param string|ComparisionOperator $operator Comparison operator to be used for test
      *
      * @dataProvider provideComparisionOperators
      */
-    public function testIfOperatorRendersContent(string $column, $value, $operator)
+    public function testIfOperatorRendersContent(string $column, mixed $value, ComparisionOperator|string $operator): void
     {
         $criteria = new CriteriaItem($column, $value, $operator);
         self::assertNotEmpty(
             $criteria->render(false),
-            'Criteria with condition ' . $operator . ' doesn\'t renders SQL (without binds)'
+            'Criteria with condition ' . $criteria->getComparisionOperator()->name . ' doesn\'t renders SQL (without binds)'
         );
         self::assertNotEmpty(
             $criteria->renderWhere(false),
-            'Criteria with condition ' . $operator . ' doesn\'t renders WHERE SQL (without binds)'
+            'Criteria with condition ' . $criteria->getComparisionOperator()->name . ' doesn\'t renders WHERE SQL (without binds)'
         );
         self::assertNotEmpty(
             $criteria->render(true),
-            'Criteria with condition ' . $operator . ' doesn\'t renders SQL (with binds)'
+            'Criteria with condition ' . $criteria->getComparisionOperator()->name . ' doesn\'t renders SQL (with binds)'
         );
         self::assertNotEmpty(
             $criteria->renderWhere(true),
-            'Criteria with condition ' . $operator . ' doesn\'t renders WHERE SQL (with binds)'
+            'Criteria with condition ' . $criteria->getComparisionOperator()->name . ' doesn\'t renders WHERE SQL (with binds)'
         );
     }
 
@@ -107,39 +110,43 @@ class CriteriaItemTest extends TestCase
      *
      * @return Generator
      */
-    public function provideOrder()
+    public function provideOrder(): Generator
     {
-        foreach (Order::values() as $order) {
-            yield [$order];
-            yield [strtolower($order)];
-            yield [ucfirst(strtolower($order))];
-            yield [' ' . $order . ' '];
+        foreach (Order::cases() as $order) {
+            yield [$order->value];
+            yield [strtolower($order->value)];
+            yield [ucfirst(strtolower($order->value))];
+            yield [' ' . $order->value . ' '];
         }
     }
 
     /**
      * Tests order with enums
      *
-     * @param Order|string $order
+     * @param string|Order $order
      *
      * @dataProvider provideOrder
+     *
+     * @throws RandomException
      */
-    public function testOrder($order)
+    public function testOrder(Order|string $order): void
     {
-        $criteria = new CriteriaItem(sha1(mt_rand(PHP_INT_MIN, PHP_INT_MAX)));
-        self::assertSame(Order::ASC()->getValue(), (string)$criteria->getOrder(), 'Default order is not correct');
+        $criteria = new CriteriaItem(sha1(random_int(PHP_INT_MIN, PHP_INT_MAX)));
+        self::assertSame(Order::ASC->value, $criteria->getOrder()->value, 'Default order is not correct');
         $criteria->setOrder($order);
-        self::assertSame(strtoupper(trim($order)), (string)$criteria->getOrder(), 'Order ' . $order . ' does\'t sets');
+        self::assertSame(strtoupper(trim($order)), $criteria->getOrder()->value, 'Order ' . $order . ' does\'t sets');
     }
 
     /**
      * Tests group by operations
+     *
+     * @throws RandomException
      */
-    public function testGroupBy()
+    public function testGroupBy(): void
     {
-        $criteria = new CriteriaItem(sha1(mt_rand(PHP_INT_MIN, PHP_INT_MAX)));
+        $criteria = new CriteriaItem(sha1(random_int(PHP_INT_MIN, PHP_INT_MAX)));
         self::assertEmpty($criteria->getGroupBy(), 'Default group by is not empty');
-        $groupBy = sha1(mt_rand(PHP_INT_MIN, PHP_INT_MAX));
+        $groupBy = sha1(random_int(PHP_INT_MIN, PHP_INT_MAX));
         $criteria->setGroupBy($groupBy);
         self::assertNotEmpty($criteria->getGroupBy(), 'Group by was set but value wasn\'t modified');
         self::assertStringStartsWith('GROUP BY', trim($criteria->getGroupBy()), 'Non empty group by doesn\' starts with "GROUP BY"');
@@ -148,12 +155,13 @@ class CriteriaItemTest extends TestCase
 
     /**
      * Tests sort by operations
+     * @throws RandomException
      */
-    public function testSortBy()
+    public function testSortBy(): void
     {
-        $criteria = new CriteriaItem(sha1(mt_rand(PHP_INT_MIN, PHP_INT_MAX)));
+        $criteria = new CriteriaItem(sha1(random_int(PHP_INT_MIN, PHP_INT_MAX)));
         self::assertEmpty($criteria->getSort(), 'Default sort by is not empty');
-        $sort = sha1(mt_rand(PHP_INT_MIN, PHP_INT_MAX));
+        $sort = sha1(random_int(PHP_INT_MIN, PHP_INT_MAX));
         $criteria->setSort($sort);
         self::assertNotEmpty($criteria->getSort(), 'Sort by was set but value wasn\'t modified');
         self::assertStringContainsString($sort, $criteria->getSort(), 'Sort by value doesn\'t exists');
@@ -161,14 +169,15 @@ class CriteriaItemTest extends TestCase
 
     /**
      * Tests limit/from by operations
+     * @throws RandomException
      */
-    public function testPartialResults()
+    public function testPartialResults(): void
     {
-        $criteria = new CriteriaItem(sha1(mt_rand(PHP_INT_MIN, PHP_INT_MAX)));
+        $criteria = new CriteriaItem(sha1(random_int(PHP_INT_MIN, PHP_INT_MAX)));
         self::assertSame(0, $criteria->getLimit(), 'Default limit is not 0');
         self::assertSame(0, $criteria->getStart(), 'Default start is not 0');
-        $limit = mt_rand(1, PHP_INT_MAX);
-        $start = mt_rand(1, PHP_INT_MAX);
+        $limit = random_int(1, PHP_INT_MAX);
+        $start = random_int(1, PHP_INT_MAX);
         $criteria->setLimit($limit)->setStart($start);
         self::assertSame($limit, $criteria->getLimit(), 'Updated limit is not same as should be');
         self::assertSame($start, $criteria->getStart(), 'Updated start is not same as should be');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the minimum required PHP version to 8.3 or higher.
  - Updated testing workflows to focus on PHP versions 8.3 and 8.4.
- **Refactor**
  - Migrated enum implementations to native PHP 8.1+ enums for better type safety.
  - Enhanced type declarations and strict typing across multiple components and traits.
  - Improved error handling and code clarity in criteria and condition handling.
  - Replaced deprecated enum methods and improved enum usage consistency.
- **Tests**
  - Modernized test suites with native enum usage and cryptographically secure randomness.
  - Added type hints and exception annotations to test methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->